### PR TITLE
remove sourceURLs from all property views

### DIFF
--- a/property/default.json
+++ b/property/default.json
@@ -57,8 +57,7 @@
         { "name": "isSold" },
         { "name": "minStay" },
         { "name": "period" },
-        { "name": "pricePerSquareFoot" },
-        { "name": "sourceURLs" }
+        { "name": "pricePerSquareFoot" }
       ]
     },
     { "name": "propertyTaxes", "flatten": false },
@@ -71,7 +70,6 @@
         { "name": "doRecommend" },
         { "name": "numHelpful" },
         { "name": "rating" },
-        { "name": "sourceURLs" },
         { "name": "text" },
         { "name": "title" },
         { "name": "userCity" },
@@ -80,7 +78,6 @@
       ]
     },
     { "name": "rules", "flatten": false },
-    { "name": "sourceURLs", "flatten": false },
     { "name": "statuses", "flatten": false },
     { "name": "taxID" },
     { "name": "websiteIDs", "flatten": false }

--- a/property/default.json
+++ b/property/default.json
@@ -3,30 +3,60 @@
   "data_type": "property",
   "fields": [
     { "name": "address" },
-    { "name": "brokers", "flatten": false },
+    { "name": "brokers", "flatten": false, "sub_fields": [
+        { "name": "agent" },
+        { "name": "company" },
+        { "name": "dateSeen" },
+        { "name": "emails" },
+        { "name": "phones" },
+        { "name": "websites" }
+      ]
+    },
     { "name": "buildingName" },
     { "name": "city" },
     { "name": "country" },
     { "name": "dateAdded" },
     { "name": "dateUpdated" },
-    { "name": "deposits", "flatten": false },
-    { "name": "descriptions", "flatten": false },
-    { "name": "domains", "flatten": false },
+    { "name": "deposits", "flatten": false, "sub_fields": [
+        { "name": "amount" },
+        { "name": "currency" },
+        { "name": "dateSeen" }
+      ]
+    },
+    { "name": "descriptions", "flatten": false, "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "value" }
+      ]
+    },
     { "name": "features", "flatten": false },
-    { "name": "fees", "flatten": false },
+    { "name": "fees", "flatten": false, "sub_fields": [
+        { "name": "amountMax" },
+        { "name": "amountMin" },
+        { "name": "currency" },
+        { "name": "dateSeen" },
+        { "name": "type" }
+      ]
+    },
     { "name": "floorSizeValue" },
     { "name": "floorSizeUnit" },
     { "name": "geoLocation"},
-    { "name": "imageURLs", "flatten": false },
     { "name": "keys", "flatten": false },
     { "name": "languagesSpoken", "flatten": false },
     { "name": "latitude" },
-    { "name": "leasingTerms", "flatten": false },
+    { "name": "leasingTerms", "flatten": false, "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "value" }
+      ]
+    },
     { "name": "listingName" },
     { "name": "longitude" },
     { "name": "lotSizeValue" },
     { "name": "lotSizeUnit" },
-    { "name": "managedBy", "flatten": false },
+    { "name": "managedBy", "flatten": false, "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "value" }
+      ]
+    },
     { "name": "mostRecentStatus" },
     { "name": "mostRecentStatusDate" },
     { "name": "mlsNumber" },
@@ -60,7 +90,12 @@
         { "name": "pricePerSquareFoot" }
       ]
     },
-    { "name": "propertyTaxes", "flatten": false },
+    { "name": "propertyTaxes", "flatten": false, "sub_fields": [
+        { "name": "amount" },
+        { "name": "currency" },
+        { "name": "dateSeen" }
+      ]
+    },
     { "name": "propertyType" },
     { "name": "province" },
     { "name": "reviews", "flatten": false, "sub_fields": [
@@ -78,7 +113,13 @@
       ]
     },
     { "name": "rules", "flatten": false },
-    { "name": "statuses", "flatten": false },
+    { "name": "statuses", "flatten": false, "sub_fields": [
+        { "name": "date" },
+        { "name": "dateSeen" },
+        { "name": "isUnderContract" },
+        { "name": "type" }
+      ]
+    },
     { "name": "taxID" },
     { "name": "websiteIDs", "flatten": false }
   ]

--- a/property/default.json
+++ b/property/default.json
@@ -40,7 +40,6 @@
     { "name": "floorSizeValue" },
     { "name": "floorSizeUnit" },
     { "name": "geoLocation"},
-    { "name": "keys", "flatten": false },
     { "name": "languagesSpoken", "flatten": false },
     { "name": "latitude" },
     { "name": "leasingTerms", "flatten": false, "sub_fields": [
@@ -120,7 +119,6 @@
         { "name": "type" }
       ]
     },
-    { "name": "taxID" },
-    { "name": "websiteIDs", "flatten": false }
+    { "name": "taxID" }
   ]
 }

--- a/property/property_flat_prices.json
+++ b/property/property_flat_prices.json
@@ -57,8 +57,7 @@
         { "name": "isSold" },
         { "name": "minStay" },
         { "name": "period" },
-        { "name": "pricePerSquareFoot" },
-        { "name": "sourceURLs" }
+        { "name": "pricePerSquareFoot" }
       ]
     },
     {"name": "propertyTaxes", "flatten": false },
@@ -66,7 +65,6 @@
     {"name": "province", "flatten": false },
     {"name": "reviews", "flatten": false },
     {"name": "rules", "flatten": false },
-    {"name": "sourceURLs", "flatten": false },
     {"name": "statuses", "flatten": false },
     {"name": "taxID", "flatten": false },
     {"name": "websiteIDs", "flatten": false }

--- a/property/property_flat_prices.json
+++ b/property/property_flat_prices.json
@@ -40,7 +40,6 @@
     { "name": "floorSizeValue" },
     { "name": "floorSizeUnit" },
     { "name": "geoLocation"},
-    { "name": "keys", "flatten": false },
     { "name": "languagesSpoken", "flatten": false },
     { "name": "latitude" },
     { "name": "leasingTerms", "flatten": false, "sub_fields": [
@@ -120,7 +119,6 @@
         { "name": "type" }
       ]
     },
-    { "name": "taxID" },
-    { "name": "websiteIDs", "flatten": false }
+    { "name": "taxID" }
   ]
 }

--- a/property/property_flat_prices.json
+++ b/property/property_flat_prices.json
@@ -2,31 +2,61 @@
   "name": "property_flat_prices",
   "data_type": "property",
   "fields": [
-    {"name": "address", "flatten": false },
-    {"name": "brokers", "flatten": false },
-    {"name": "buildingName", "flatten": false },
-    {"name": "city", "flatten": false },
-    {"name": "country", "flatten": false },
-    {"name": "dateAdded", "flatten": false },
-    {"name": "dateUpdated", "flatten": false },
-    {"name": "deposits", "flatten": false },
-    {"name": "descriptions", "flatten": false },
-    {"name": "domains", "flatten": false},
-    {"name": "features", "flatten": false },
-    {"name": "fees", "flatten": false },
-    {"name": "floorSizeValue", "flatten": false },
-    {"name": "floorSizeUnit", "flatten": false },
-    {"name": "geoLocation"},
-    {"name": "imageURLs", "flatten": false },
-    {"name": "keys", "flatten": false },
-    {"name": "languagesSpoken", "flatten": false },
-    {"name": "latitude", "flatten": false },
-    {"name": "leasingTerms", "flatten": false },
-    {"name": "listingName", "flatten": false },
-    {"name": "longitude", "flatten": false },
-    {"name": "lotSizeValue", "flatten": false },
-    {"name": "lotSizeUnit", "flatten": false },
-    {"name": "managedBy", "flatten": false },
+    { "name": "address" },
+    { "name": "brokers", "flatten": false, "sub_fields": [
+        { "name": "agent" },
+        { "name": "company" },
+        { "name": "dateSeen" },
+        { "name": "emails" },
+        { "name": "phones" },
+        { "name": "websites" }
+      ]
+    },
+    { "name": "buildingName" },
+    { "name": "city" },
+    { "name": "country" },
+    { "name": "dateAdded" },
+    { "name": "dateUpdated" },
+    { "name": "deposits", "flatten": false, "sub_fields": [
+        { "name": "amount" },
+        { "name": "currency" },
+        { "name": "dateSeen" }
+      ]
+    },
+    { "name": "descriptions", "flatten": false, "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "value" }
+      ]
+    },
+    { "name": "features", "flatten": false },
+    { "name": "fees", "flatten": false, "sub_fields": [
+        { "name": "amountMax" },
+        { "name": "amountMin" },
+        { "name": "currency" },
+        { "name": "dateSeen" },
+        { "name": "type" }
+      ]
+    },
+    { "name": "floorSizeValue" },
+    { "name": "floorSizeUnit" },
+    { "name": "geoLocation"},
+    { "name": "keys", "flatten": false },
+    { "name": "languagesSpoken", "flatten": false },
+    { "name": "latitude" },
+    { "name": "leasingTerms", "flatten": false, "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "value" }
+      ]
+    },
+    { "name": "listingName" },
+    { "name": "longitude" },
+    { "name": "lotSizeValue" },
+    { "name": "lotSizeUnit" },
+    { "name": "managedBy", "flatten": false, "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "value" }
+      ]
+    },
     {"name": "mostRecentStatus", "flatten": false },
     {"name": "mostRecentStatusDate"},
     {"name": "mlsNumber", "flatten": false },
@@ -60,13 +90,37 @@
         { "name": "pricePerSquareFoot" }
       ]
     },
-    {"name": "propertyTaxes", "flatten": false },
-    {"name": "propertyType", "flatten": false },
-    {"name": "province", "flatten": false },
-    {"name": "reviews", "flatten": false },
-    {"name": "rules", "flatten": false },
-    {"name": "statuses", "flatten": false },
-    {"name": "taxID", "flatten": false },
-    {"name": "websiteIDs", "flatten": false }
+    { "name": "propertyTaxes", "flatten": false, "sub_fields": [
+        { "name": "amount" },
+        { "name": "currency" },
+        { "name": "dateSeen" }
+      ]
+    },
+    { "name": "propertyType" },
+    { "name": "province" },
+    { "name": "reviews", "flatten": false, "sub_fields": [
+        { "name": "date" },
+        { "name": "dateSeen" },
+        { "name": "didPurchase" },
+        { "name": "doRecommend" },
+        { "name": "numHelpful" },
+        { "name": "rating" },
+        { "name": "text" },
+        { "name": "title" },
+        { "name": "userCity" },
+        { "name": "username" },
+        { "name": "userProvince" }
+      ]
+    },
+    { "name": "rules", "flatten": false },
+    { "name": "statuses", "flatten": false, "sub_fields": [
+        { "name": "date" },
+        { "name": "dateSeen" },
+        { "name": "isUnderContract" },
+        { "name": "type" }
+      ]
+    },
+    { "name": "taxID" },
+    { "name": "websiteIDs", "flatten": false }
   ]
 }

--- a/property/property_flat_reviews.json
+++ b/property/property_flat_reviews.json
@@ -2,49 +2,100 @@
   "name": "property_flat_reviews",
   "data_type": "property",
   "fields": [
-    {"name": "address", "flatten": false },
-    {"name": "brokers", "flatten": false },
-    {"name": "buildingName", "flatten": false },
-    {"name": "city", "flatten": false },
-    {"name": "country", "flatten": false },
-    {"name": "dateAdded", "flatten": false },
-    {"name": "dateUpdated", "flatten": false },
-    {"name": "deposits", "flatten": false },
-    {"name": "descriptions", "flatten": false },
-    {"name": "domains", "flatten": false},
-    {"name": "features", "flatten": false },
-    {"name": "fees", "flatten": false },
-    {"name": "floorSizeValue", "flatten": false },
-    {"name": "floorSizeUnit", "flatten": false },
-    {"name": "geoLocation"},
-    {"name": "imageURLs", "flatten": false },
-    {"name": "keys", "flatten": false },
-    {"name": "languagesSpoken", "flatten": false },
-    {"name": "latitude", "flatten": false },
-    {"name": "leasingTerms", "flatten": false },
-    {"name": "listingName", "flatten": false },
-    {"name": "longitude", "flatten": false },
-    {"name": "lotSizeValue", "flatten": false },
-    {"name": "lotSizeUnit", "flatten": false },
-    {"name": "managedBy", "flatten": false },
-    {"name": "mostRecentStatus", "flatten": false },
-    {"name": "mostRecentStatusDate"},
-    {"name": "mlsNumber", "flatten": false },
-    {"name": "neighborhoods", "flatten": false },
-    {"name": "numBathroom", "flatten": false },
-    {"name": "numBedroom", "flatten": false },
-    {"name": "numFloor", "flatten": false },
-    {"name": "numPeople", "flatten": false },
-    {"name": "numRoom", "flatten": false },
-    {"name": "numUnit", "flatten": false },
-    {"name": "parking", "flatten": false },
-    {"name": "paymentTypes", "flatten": false },
-    {"name": "people", "flatten": false },
-    {"name": "petPolicy", "flatten": false },
-    {"name": "phones", "flatten": false },
-    {"name": "postalCode", "flatten": false },
-    {"name": "prices", "flatten": false },
-    {"name": "propertyTaxes", "flatten": false },
+    { "name": "address" },
+    { "name": "brokers", "flatten": false, "sub_fields": [
+        { "name": "agent" },
+        { "name": "company" },
+        { "name": "dateSeen" },
+        { "name": "emails" },
+        { "name": "phones" },
+        { "name": "websites" }
+      ]
+    },
+    { "name": "buildingName" },
+    { "name": "city" },
+    { "name": "country" },
+    { "name": "dateAdded" },
+    { "name": "dateUpdated" },
+    { "name": "deposits", "flatten": false, "sub_fields": [
+        { "name": "amount" },
+        { "name": "currency" },
+        { "name": "dateSeen" }
+      ]
+    },
+    { "name": "descriptions", "flatten": false, "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "value" }
+      ]
+    },
+    { "name": "features", "flatten": false },
+    { "name": "fees", "flatten": false, "sub_fields": [
+        { "name": "amountMax" },
+        { "name": "amountMin" },
+        { "name": "currency" },
+        { "name": "dateSeen" },
+        { "name": "type" }
+      ]
+    },
+    { "name": "floorSizeValue" },
+    { "name": "floorSizeUnit" },
+    { "name": "geoLocation"},
+    { "name": "keys", "flatten": false },
+    { "name": "languagesSpoken", "flatten": false },
+    { "name": "latitude" },
+    { "name": "leasingTerms", "flatten": false, "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "value" }
+      ]
+    },
+    { "name": "listingName" },
+    { "name": "longitude" },
+    { "name": "lotSizeValue" },
+    { "name": "lotSizeUnit" },
+    { "name": "managedBy", "flatten": false, "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "value" }
+      ]
+    },
+    { "name": "mostRecentStatus" },
+    { "name": "mostRecentStatusDate" },
+    { "name": "mlsNumber" },
+    { "name": "neighborhoods", "flatten": false },
+    { "name": "numBathroom" },
+    { "name": "numBedroom" },
+    { "name": "numFloor" },
+    { "name": "numPeople" },
+    { "name": "numRoom" },
+    { "name": "numUnit" },
+    { "name": "parking", "flatten": false },
+    { "name": "paymentTypes", "flatten": false },
+    { "name": "people", "flatten": false },
+    { "name": "petPolicy" },
+    { "name": "phones", "flatten": false },
+    { "name": "postalCode" },
+    { "name": "prices", "flatten": false, "sub_fields": [
+        { "name": "amountMax" },
+        { "name": "amountMin" },
+        { "name": "availability" },
+        { "name": "comment" },
+        { "name": "currency" },
+        { "name": "date" },
+        { "name": "dateSeen" },
+        { "name": "dateValidStart" },
+        { "name": "dateValidEnd" },
+        { "name": "isSale" },
+        { "name": "isSold" },
+        { "name": "minStay" },
+        { "name": "period" },
+        { "name": "pricePerSquareFoot" }
+      ]
+    },
+    { "name": "propertyTaxes", "flatten": false, "sub_fields": [
+        { "name": "amount" },
+        { "name": "currency" },
+        { "name": "dateSeen" }
+      ]
+    },
     {"name": "propertyType", "flatten": false },
     {"name": "province", "flatten": false },
     { "name": "reviews", "flatten": true, "sub_fields": [
@@ -61,9 +112,15 @@
         { "name": "userProvince" }
       ]
     },
-    {"name": "rules", "flatten": false },
-    {"name": "statuses", "flatten": false },
-    {"name": "taxID", "flatten": false },
-    {"name": "websiteIDs", "flatten": false }
+    { "name": "rules", "flatten": false },
+    { "name": "statuses", "flatten": false, "sub_fields": [
+        { "name": "date" },
+        { "name": "dateSeen" },
+        { "name": "isUnderContract" },
+        { "name": "type" }
+      ]
+    },
+    { "name": "taxID" },
+    { "name": "websiteIDs", "flatten": false }
   ]
 }

--- a/property/property_flat_reviews.json
+++ b/property/property_flat_reviews.json
@@ -54,7 +54,6 @@
         { "name": "doRecommend" },
         { "name": "numHelpful" },
         { "name": "rating" },
-        { "name": "sourceURLs" },
         { "name": "text" },
         { "name": "title" },
         { "name": "userCity" },
@@ -63,7 +62,6 @@
       ]
     },
     {"name": "rules", "flatten": false },
-    {"name": "sourceURLs", "flatten": false },
     {"name": "statuses", "flatten": false },
     {"name": "taxID", "flatten": false },
     {"name": "websiteIDs", "flatten": false }

--- a/property/property_flat_reviews.json
+++ b/property/property_flat_reviews.json
@@ -39,7 +39,7 @@
     },
     { "name": "floorSizeValue" },
     { "name": "floorSizeUnit" },
-    { "name": "geoLocation"}
+    { "name": "geoLocation"},
     { "name": "latitude" },
     { "name": "leasingTerms", "flatten": false, "sub_fields": [
         { "name": "dateSeen" },

--- a/property/property_flat_reviews.json
+++ b/property/property_flat_reviews.json
@@ -39,9 +39,7 @@
     },
     { "name": "floorSizeValue" },
     { "name": "floorSizeUnit" },
-    { "name": "geoLocation"},
-    { "name": "keys", "flatten": false },
-    { "name": "languagesSpoken", "flatten": false },
+    { "name": "geoLocation"}
     { "name": "latitude" },
     { "name": "leasingTerms", "flatten": false, "sub_fields": [
         { "name": "dateSeen" },
@@ -120,7 +118,6 @@
         { "name": "type" }
       ]
     },
-    { "name": "taxID" },
-    { "name": "websiteIDs", "flatten": false }
+    { "name": "taxID" }
   ]
 }


### PR DESCRIPTION
### Overview
Removed the following from property views:
- `sourceURLs`
- `prices.sourceURLs`
- `reviews.sourceURLs`

### Verify Changes

1. Merge changes into master
2. Notify the INFRASTRUCTURE team to update the API.
3. Once updated, verify it exists via:
* GET https://api.datafiniti.co/v4/default-views
* Note: You can view that in the browser ^
