### PR TITLE
exclude people contact data from non default stock views

### DIFF
--- a/property/property_flat_prices.json
+++ b/property/property_flat_prices.json
@@ -179,21 +179,43 @@
         { "name": "endDate" }
       ]
     },
-    { "name": "parcelNumbers", "flatten": false, "sub_fields": [
+    {
+      "name": "parcelNumbers",
+      "flatten": false,
+      "sub_fields": [
         { "name": "number" },
         { "name": "account" },
         { "name": "year" }
       ]
     },
-    {"name": "parking", "flatten": false },
-    {"name": "parkingTypes", "flatten": false },
-    {"name": "paymentTypes", "flatten": false },
-    {"name": "people", "flatten": false },
-    {"name": "petPolicy", "flatten": false },
-    {"name": "permits", "flatten": false },
-    {"name": "phones", "flatten": false },
-    {"name": "postalCode", "flatten": false },
-    { "name": "prices", "flatten": true, "sub_fields": [
+    { "name": "parking", "flatten": false },
+    { "name": "parkingTypes", "flatten": false },
+    { "name": "paymentTypes", "flatten": false },
+    {
+      "name": "people",
+      "flatten": false,
+      "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "startDate" },
+        { "name": "endDate" },
+        { "name": "equity" },
+        { "name": "equityPercent" },
+        { "name": "landline" },
+        { "name": "name" },
+        { "name": "firstName" },
+        { "name": "lastName" },
+        { "name": "title" },
+        { "name": "people_key" }
+      ]
+    },
+    { "name": "petPolicy", "flatten": false },
+    { "name": "permits", "flatten": false },
+    { "name": "phones", "flatten": false },
+    { "name": "postalCode", "flatten": false },
+    {
+      "name": "prices",
+      "flatten": true,
+      "sub_fields": [
         { "name": "amountMax" },
         { "name": "amountMin" },
         { "name": "availability" },

--- a/property/property_flat_reviews.json
+++ b/property/property_flat_reviews.json
@@ -186,12 +186,31 @@
     { "name": "parking", "flatten": false },
     { "name": "parkingTypes", "flatten": false },
     { "name": "paymentTypes", "flatten": false },
-    { "name": "people", "flatten": false },
+    {
+      "name": "people",
+      "flatten": false,
+      "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "startDate" },
+        { "name": "endDate" },
+        { "name": "equity" },
+        { "name": "equityPercent" },
+        { "name": "landline" },
+        { "name": "name" },
+        { "name": "firstName" },
+        { "name": "lastName" },
+        { "name": "title" },
+        { "name": "people_key" }
+      ]
+    },
     { "name": "petPolicy" },
     { "name": "permits", "flatten": false },
     { "name": "phones", "flatten": false },
     { "name": "postalCode" },
-    { "name": "prices", "flatten": false, "sub_fields": [
+    {
+      "name": "prices",
+      "flatten": false,
+      "sub_fields": [
         { "name": "amountMax" },
         { "name": "amountMin" },
         { "name": "availability" },

--- a/property/property_preview.json
+++ b/property/property_preview.json
@@ -66,7 +66,23 @@
     { "name": "numPeople" },
     { "name": "numRoom" },
     { "name": "numUnit" },
-    { "name": "people", "flatten": false },
+    {
+      "name": "people",
+      "flatten": false,
+      "sub_fields": [
+        { "name": "dateSeen" },
+        { "name": "startDate" },
+        { "name": "endDate" },
+        { "name": "equity" },
+        { "name": "equityPercent" },
+        { "name": "landline" },
+        { "name": "name" },
+        { "name": "firstName" },
+        { "name": "lastName" },
+        { "name": "title" },
+        { "name": "people_key" }
+      ]
+    },
     { "name": "postalCode" },
     { "name": "propertyType" },
     { "name": "province" }


### PR DESCRIPTION
### Overview
We previously made changes to exclude people contact data from the default view but not from the other stock views, maybe this was intentional but I'm assuming it was an oversight.

### Verify Changes

1. Merge changes into master
2. Notify the INFRASTRUCTURE team to update the API.
3. Once updated, verify it exists via:
* GET https://api.datafiniti.co/v4/default-views
* Note: You can view that in the browser ^
